### PR TITLE
Handling Unfinished Jobs

### DIFF
--- a/ga_dashboard/backend/ga_tools.py
+++ b/ga_dashboard/backend/ga_tools.py
@@ -126,7 +126,7 @@ def extract_data(config_data: dict, has_slurmAdmin: bool, cluster_info) -> pd.Da
 
 
     ### Turn usage logs into DataFrame
-    WM.convert2dataframe()
+    WM.raw_logs_to_df()
 
     ###### Running jobs can be filtered and saved into the DB here. 
     ###### Subsquently they can be removed from WM logs before proceeding with cleaning of logs.

--- a/ga_dashboard/backend/ga_tools.py
+++ b/ga_dashboard/backend/ga_tools.py
@@ -131,8 +131,9 @@ def extract_data(config_data: dict, has_slurmAdmin: bool, cluster_info) -> pd.Da
   
     WM.filter_and_store_unfinished_jobs(unfin_jobs_service) # Filter unifinshed jobs from WM logs and store them in DB
 
-    WM.concat_logs_df(finished_jobs_df) #concat finished jobs (previously unfinished) with rest of the logs
-    ### TODO Delete the jobs that have finished from DB
+    if finished_jobs_df is not None:
+        WM.concat_logs_df(finished_jobs_df) #concat finished jobs (previously unfinished) with rest of the logs
+
     # And clean
     WM.clean_logs_df()
     # Check if there are any jobs during the period from this directory and with these jobIDs
@@ -145,7 +146,7 @@ def extract_data(config_data: dict, has_slurmAdmin: bool, cluster_info) -> pd.Da
 
     # WM.df_agg_X.to_pickle("testdata/df_agg_X_1.pkl") # DEBUGONLY used to test different steps offline
 
-    return WM.df_agg_X
+    return WM.df_agg_X, unfin_jobs_service
 
 
 def enrich_data(df: pd.DataFrame, fixed_params: dict, users_df: pd.DataFrame, GA: GA_tools) -> pd.DataFrame:
@@ -330,7 +331,7 @@ def main_backend(config_data: dict):
 
     GA = GA_tools(cluster_info, fixed_params)
 
-    df = extract_data(config_data, has_slurmAdmin, cluster_info=cluster_info)
+    df, finished_jobids = extract_data(config_data, has_slurmAdmin, cluster_info=cluster_info)
     df2 = enrich_data(df, fixed_params=fixed_params, users_df=users_df, GA=GA)
     summary_stats = summarise_data(df2) # TODO export and save df_userdaily regularly (as a more manageable database than all individual jobs?)
 
@@ -341,12 +342,11 @@ def main_backend(config_data: dict):
     # except Exception:
     #     dict_keys = args._asdict().keys() # This is when using the debugging namedtuples TODO this a bit messy, should be cleaned up
     if 'db_name' in dict_keys:
-        process_and_store(summary_stats, config_data)
-
+        process_and_store(summary_stats, config_data, finished_jobids)
     return summary_stats
 
 
-def process_and_store(summary_stats:dict,config_data:dict) -> None:
+def process_and_store(summary_stats:dict,config_data:dict, unfin_jobs_service:UnfinishedJobsService) -> None:
     # Import aggregated data into a database
     db_params = DBSettings(
         db_name=config_data['db_name'],
@@ -359,4 +359,13 @@ def process_and_store(summary_stats:dict,config_data:dict) -> None:
                 summary_stats,
                 db_params
             )
-    data2db.insert_data_into_db()
+    try: 
+        data2db.insert_data_into_db()
+    except Exception as e:
+        print(f"Error occurred while inserting data into database: {e}")
+        return
+    
+    #only delete the finished jobs from ga_unfinished_jobs table after the new data has been successfully inserted
+    unfin_jobs_service.delete_resolved_unfinished_jobs()
+    
+        

--- a/ga_dashboard/backend/ga_tools.py
+++ b/ga_dashboard/backend/ga_tools.py
@@ -126,11 +126,13 @@ def extract_data(config_data: dict, has_slurmAdmin: bool, cluster_info) -> pd.Da
     ### Turn usage logs into DataFrame
     WM.raw_logs_to_df()
 
-    finished_jobs_df = unfin_jobs_service.sync_unfinished_jobs() #Adding finished jobs to WM before cleaning and processing 
-    WM.concat_logs_df(finished_jobs_df) 
-    ###### Running jobs can be filtered and saved into the DB here. 
-    ###### Subsquently they can be removed from WM logs before proceeding with cleaning of logs.
+    # get unfinished jobs from db and pick those that have now finished using sacct command by job id
+    finished_jobs_df = unfin_jobs_service.sync_unfinished_jobs() 
+  
+    WM.filter_and_store_unfinished_jobs(unfin_jobs_service) # Filter unifinshed jobs from WM logs and store them in DB
 
+    WM.concat_logs_df(finished_jobs_df) #concat finished jobs (previously unfinished) with rest of the logs
+    ### TODO Delete the jobs that have finished from DB
     # And clean
     WM.clean_logs_df()
     # Check if there are any jobs during the period from this directory and with these jobIDs
@@ -228,7 +230,7 @@ def summarise_data(df: pd.DataFrame) -> dict:
             timeseries = data.groupby(agg_names2).agg(**agg_functions_from_raw)
         else:
             timeseries = data.groupby(agg_names2).agg(**agg_functions_further)
-
+ 
         timeseries.reset_index(inplace=True, drop=(agg_names is None))
         timeseries['success_rate'] = timeseries.n_success / timeseries.n_jobs
         timeseries['failure_rate'] = 1 - timeseries.success_rate
@@ -236,8 +238,7 @@ def summarise_data(df: pd.DataFrame) -> dict:
 
         return timeseries
 
-    df['SubmitDate'] = df.SubmitDatetimeX.dt.date  # TODO do it with real start time rather than submit day
-
+    df['SubmitDate'] = df.SubmitDatetimeX.dt.date  # TODO do it with real start time rather than submit date
     has_slurmAdmin = True # get_slurmAdmin(args) # We only assume we have admin access now
 
     if has_slurmAdmin:
@@ -262,6 +263,7 @@ def summarise_data(df: pd.DataFrame) -> dict:
 
         df_overallStats = agg_jobs(df_daily)
         dict_overallStats = df_overallStats.iloc[0, :].to_dict()
+
 
         ## And put everything in a dict
         output = {

--- a/ga_dashboard/backend/ga_tools.py
+++ b/ga_dashboard/backend/ga_tools.py
@@ -9,6 +9,7 @@ import yaml
 import ga_dashboard.backend.helpers.utils as utils
 from ga_dashboard.backend.data_sql_import import DataSQLImport
 from ga_dashboard.backend.services.database_service import DBSettings
+from ga_dashboard.backend.services.unfinished_jobs_service import UnfinishedJobsService
 from ga_dashboard.backend.workload_manager.slurm import SlurmManager
 
 
@@ -120,14 +121,13 @@ def extract_data(config_data: dict, has_slurmAdmin: bool, cluster_info) -> pd.Da
     ### Log the output for debugging
     utils.save_slurm_logs(config_data, WM)
 
-
-    ###### Here we can fetch running jobs from the DB and check if they are completed. 
-    ###### If they are we can maybe create a different WM object with them and run convert2dataframe() command
-
+    unfin_jobs_service = UnfinishedJobsService(config_data)
 
     ### Turn usage logs into DataFrame
     WM.raw_logs_to_df()
 
+    finished_jobs_df = unfin_jobs_service.sync_unfinished_jobs() #Adding finished jobs to WM before cleaning and processing 
+    WM.concat_logs_df(finished_jobs_df) 
     ###### Running jobs can be filtered and saved into the DB here. 
     ###### Subsquently they can be removed from WM logs before proceeding with cleaning of logs.
 

--- a/ga_dashboard/backend/ga_tools.py
+++ b/ga_dashboard/backend/ga_tools.py
@@ -121,15 +121,15 @@ def extract_data(config_data: dict, has_slurmAdmin: bool, cluster_info) -> pd.Da
     ### Log the output for debugging
     utils.save_slurm_logs(config_data, WM)
 
-    unfin_jobs_service = UnfinishedJobsService(config_data)
+    unfinished_jobs_service = UnfinishedJobsService(config_data)
 
     ### Turn usage logs into DataFrame
     WM.raw_logs_to_df()
 
     # get unfinished jobs from db and pick those that have now finished using sacct command by job id
-    finished_jobs_df = unfin_jobs_service.sync_unfinished_jobs() 
+    finished_jobs_df = unfinished_jobs_service.sync_unfinished_jobs() 
   
-    WM.filter_and_store_unfinished_jobs(unfin_jobs_service) # Filter unifinshed jobs from WM logs and store them in DB
+    WM.filter_and_store_unfinished_jobs(unfinished_jobs_service) # Filter unifinshed jobs from WM logs and store them in DB
 
     if finished_jobs_df is not None:
         WM.concat_logs_df(finished_jobs_df) #concat finished jobs (previously unfinished) with rest of the logs
@@ -146,7 +146,7 @@ def extract_data(config_data: dict, has_slurmAdmin: bool, cluster_info) -> pd.Da
 
     # WM.df_agg_X.to_pickle("testdata/df_agg_X_1.pkl") # DEBUGONLY used to test different steps offline
 
-    return WM.df_agg_X, unfin_jobs_service
+    return WM.df_agg_X, unfinished_jobs_service
 
 
 def enrich_data(df: pd.DataFrame, fixed_params: dict, users_df: pd.DataFrame, GA: GA_tools) -> pd.DataFrame:
@@ -346,7 +346,7 @@ def main_backend(config_data: dict):
     return summary_stats
 
 
-def process_and_store(summary_stats:dict,config_data:dict, unfin_jobs_service:UnfinishedJobsService) -> None:
+def process_and_store(summary_stats:dict,config_data:dict, unfinished_jobs_service:UnfinishedJobsService) -> None:
     # Import aggregated data into a database
     db_params = DBSettings(
         db_name=config_data['db_name'],
@@ -366,6 +366,6 @@ def process_and_store(summary_stats:dict,config_data:dict, unfin_jobs_service:Un
         return
     
     #only delete the finished jobs from ga_unfinished_jobs table after the new data has been successfully inserted
-    unfin_jobs_service.delete_resolved_unfinished_jobs()
+    unfinished_jobs_service.delete_resolved_unfinished_jobs()
     
         

--- a/ga_dashboard/backend/helpers/utils.py
+++ b/ga_dashboard/backend/helpers/utils.py
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------------
 
 import datetime
+from io import BytesIO
 import os
 import sys
 import random
@@ -99,5 +100,30 @@ def save_slurm_logs(config_data, WM) -> None: # DEBUGONLY
             f.write(WM.logs_raw)
 
         print(f"\nSLURM statistics saved for inspection: {log_path}\n")
+
+
+def convert2dataframe(df_raw, types=None, delimiter="|"):
+    """
+    Convert raw logs output into a pandas DataFrame.
+    """
+    df = pd.read_csv(BytesIO(df_raw), sep=delimiter, dtype='str')
+
+    if types:
+        for c, t in types.items():
+            if c in df.columns:
+                df[c] = df[c].astype(t)
+    return df
+
+##DEBUGONLY 
+def quick_inspect(df: pd.DataFrame, name: str = "DataFrame") -> None:
+    """
+    Utility function to quickly inspect a DataFrame by printing its shape, columns, datatypes, and head.
+    """
+    print(f"--- Quick Inspection of {name} ---")
+    print("Shape:", df.shape)
+    print("Columns:", df.columns.tolist())
+    print("Dtypes:\n", df.dtypes)
+    print("Head:\n", df.head())
+    print(f"--- End of {name} Inspection ---\n")
 
 

--- a/ga_dashboard/backend/helpers/utils.py
+++ b/ga_dashboard/backend/helpers/utils.py
@@ -102,12 +102,19 @@ def save_slurm_logs(config_data, WM) -> None: # DEBUGONLY
         print(f"\nSLURM statistics saved for inspection: {log_path}\n")
 
 
-def convert2dataframe(df_raw, types=None, delimiter="|"):
+def convert2dataframe(df_raw: bytes, types: dict | None = None, delimiter="|"):
     """
     Convert raw logs output into a pandas DataFrame.
+    Parameters:
+        df_raw : Raw logs output as bytes.
+        types : column names and their desired data types. E.g., {'NNodes': 'int64', 'NCPUS': 'int64'}
+        delimiter : Delimiter used in the raw logs.
+    Returns:
+        pd.DataFrame: DataFrame containing the parsed logs with specified data types.
     """
     df = pd.read_csv(BytesIO(df_raw), sep=delimiter, dtype='str')
 
+    # Convert specified columns to appropriate data types 
     if types:
         for c, t in types.items():
             if c in df.columns:

--- a/ga_dashboard/backend/services/database_service.py
+++ b/ga_dashboard/backend/services/database_service.py
@@ -268,34 +268,36 @@ class DatabaseService:
             cur.close()
 
 
-    def delete_by_column_values(conn, table_name: str, column_name: str, values: list) -> int:
+    def delete_by_column_values(self, table_name: str, column_name: str, values: list) -> int:
         """
         Delete rows from a table where column_name matches any value in values.
         Returns number of deleted rows.
         """
-        if not values:
+        if not self._conn or self._conn.closed:
+            logger.error("No active database connection. Call connect() first.")
             return 0
 
+        if not values:
+            logger.debug("No values provided for deletion.")
+            return 0
+
+        cur = self._conn.cursor()
         try:
-            with conn.cursor() as cur:
-                query = sql.SQL("""
-                    DELETE FROM {table}
-                    WHERE {column} = ANY(%s)
-                    """).format(
-                        table=sql.Identifier(table_name),
-                        column=sql.Identifier(column_name),
-                    )
-
-                cur.execute(query, (values,))
-                deleted = cur.rowcount
-
-            conn.commit()
+            query = sql.SQL("""
+                DELETE FROM {table}
+                WHERE {column} = ANY(%s)
+            """).format(
+                table=sql.Identifier(table_name),
+                column=sql.Identifier(column_name),
+            )
+            cur.execute(query, (values,))
+            deleted = cur.rowcount
+            self._conn.commit()
+            logger.debug(f"Deleted {deleted} rows from '{table_name}' where {column_name} in values.")
             return deleted
-
-        except Exception:
-            conn.rollback()
+        except Exception as e:
+            logger.error(f"Error deleting from '{table_name}': {e}")
+            self._conn.rollback()
             raise
-
         finally:
-            if cur is not None:
-                cur.close()
+            cur.close()

--- a/ga_dashboard/backend/services/database_service.py
+++ b/ga_dashboard/backend/services/database_service.py
@@ -6,6 +6,7 @@ import logging
 import psycopg
 import pandas as pd
 from dataclasses import dataclass
+from psycopg import sql
 
 logger = logging.getLogger(__name__)
 
@@ -265,3 +266,36 @@ class DatabaseService:
             return pd.DataFrame()
         finally:
             cur.close()
+
+
+    def delete_by_column_values(conn, table_name: str, column_name: str, values: list) -> int:
+        """
+        Delete rows from a table where column_name matches any value in values.
+        Returns number of deleted rows.
+        """
+        if not values:
+            return 0
+
+        try:
+            with conn.cursor() as cur:
+                query = sql.SQL("""
+                    DELETE FROM {table}
+                    WHERE {column} = ANY(%s)
+                    """).format(
+                        table=sql.Identifier(table_name),
+                        column=sql.Identifier(column_name),
+                    )
+
+                cur.execute(query, (values,))
+                deleted = cur.rowcount
+
+            conn.commit()
+            return deleted
+
+        except Exception:
+            conn.rollback()
+            raise
+
+        finally:
+            if cur is not None:
+                cur.close()

--- a/ga_dashboard/backend/services/sacct_service.py
+++ b/ga_dashboard/backend/services/sacct_service.py
@@ -36,18 +36,21 @@ class SacctService:
         logs = subprocess.run(bash_com_full, capture_output=True)
         return logs.stdout      
 
-    # @classmethod
-    # def pull_logs_by_jobid(cls, unfinished_jobs_df: pd.DataFrame | None = None):
-    #     """
-    #     Pull SLURM usage logs for jobs using sacct command. Can optionally fetch only specific JobIDs from a DataFrame.
+    @classmethod
+    def pull_logs_by_jobid(cls, unfinished_jobs_df: pd.DataFrame | None = None):
+        """
+        Pull SLURM usage logs for jobs using sacct command. Can optionally fetch only specific JobIDs from a DataFrame.
         
-    #     Args:
-    #         unfinished_jobs_df: Optional DataFrame containing a column 'JobID'. If provided, only these jobs are fetched.
-    #     """
+        Args:
+            unfinished_jobs_df: Optional DataFrame containing a column 'JobID'. If provided, only these jobs are fetched.
+        """
 
-    #     if unfinished_jobs_df is not None and not unfinished_jobs_df.empty:
-    #         jobid_list = unfinished_jobs_df['JobID'].astype(str).tolist()
-    #         bash_com_full = cls.bash_com + ["--jobs", ",".join(jobid_list)]
+        if unfinished_jobs_df is not None and not unfinished_jobs_df.empty:
+            jobid_list = unfinished_jobs_df['JobID'].astype(str).tolist()
+            bash_com_full = cls.bash_com + ["--jobs", ",".join(jobid_list)]
         
-    #     logs = subprocess.run(bash_com_full, capture_output=True)
-    #     return logs.stdout
+            logs = subprocess.run(bash_com_full, capture_output=True)
+            return logs.stdout
+        # with open("tests/testdata/sacct_logs.raw", "rb") as f:
+        #     logs_bytes = f.read()
+        #     return logs_bytes

--- a/ga_dashboard/backend/services/sacct_service.py
+++ b/ga_dashboard/backend/services/sacct_service.py
@@ -46,7 +46,7 @@ class SacctService:
         """
 
         if unfinished_jobs_df is not None and not unfinished_jobs_df.empty:
-            jobid_list = unfinished_jobs_df['JobID'].astype(str).tolist()
+            jobid_list = unfinished_jobs_df['jobid'].astype(str).tolist()
             bash_com_full = cls.bash_com + ["--jobs", ",".join(jobid_list)]
         
             logs = subprocess.run(bash_com_full, capture_output=True)

--- a/ga_dashboard/backend/services/sacct_service.py
+++ b/ga_dashboard/backend/services/sacct_service.py
@@ -28,13 +28,18 @@ class SacctService:
         All Jobs started between the given start date and end date are pulled.
         More: https://slurm.schedmd.com/sacct.html
         """
-        bash_com_full = cls.bash_com + [
-            "--starttime", startDay,
-            "--endtime", endDay
-        ]
+        try:
+            bash_com_full = cls.bash_com + [
+                "--starttime", startDay,
+                "--endtime", endDay
+            ]
 
-        logs = subprocess.run(bash_com_full, capture_output=True)
-        return logs.stdout      
+            logs = subprocess.run(bash_com_full, capture_output=True)
+            return logs.stdout   
+        except Exception as e:
+            print(f"Error occurred while pulling logs by time using sacct: {e}")
+        finally:
+            return None 
 
     @classmethod
     def pull_logs_by_jobid(cls, unfinished_jobs_df: pd.DataFrame | None = None):
@@ -44,13 +49,14 @@ class SacctService:
         Args:
             unfinished_jobs_df: Optional DataFrame containing a column 'JobID'. If provided, only these jobs are fetched.
         """
-
-        if unfinished_jobs_df is not None and not unfinished_jobs_df.empty:
-            jobid_list = unfinished_jobs_df['jobid'].astype(str).tolist()
-            bash_com_full = cls.bash_com + ["--jobs", ",".join(jobid_list)]
-        
-            logs = subprocess.run(bash_com_full, capture_output=True)
-            return logs.stdout
-        # with open("tests/testdata/sacct_logs.raw", "rb") as f:
-        #     logs_bytes = f.read()
-        #     return logs_bytes
+        try: 
+            if unfinished_jobs_df is not None and not unfinished_jobs_df.empty:
+                jobid_list = unfinished_jobs_df['jobid'].astype(str).tolist()
+                bash_com_full = cls.bash_com + ["--jobs", ",".join(jobid_list)]
+            
+                logs = subprocess.run(bash_com_full, capture_output=True)
+                return logs.stdout
+        except Exception as e:
+            print(f"Error occurred while pulling logs by JobID using sacct: {e}")
+        finally:
+            return None

--- a/ga_dashboard/backend/services/unfinished_jobs_service.py
+++ b/ga_dashboard/backend/services/unfinished_jobs_service.py
@@ -13,7 +13,7 @@ FINISHED_STATES = ['BOOT_FAIL','CANCELLED','COMPLETED','DEADLINE','FAILED','NODE
 UNFINISHED_STATES = ['PENDING','RUNNING','SUSPENDED','UNKNOWN','PREEMPTED']
 
 class UnfinishedJobsService:
-    def __init__(self, config_data):
+    def __init__(self, config_data: dict):
         self.config_data = config_data
         self.db_params = DBSettings(
                 db_name=self.config_data['db_name'],

--- a/ga_dashboard/backend/services/unfinished_jobs_service.py
+++ b/ga_dashboard/backend/services/unfinished_jobs_service.py
@@ -1,0 +1,34 @@
+import pandas as pd
+
+## States from SLURM documentation: https://slurm.schedmd.com/job_state_codes.html (as of 10 Feb 2026)
+
+SLURM_STATES = ['BOOT_FAIL','CANCELLED','COMPLETED','DEADLINE','FAILED','NODE_FAIL','OUT_OF_MEMORY','PENDING','PREEMPTED','RUNNING','SUSPENDED','TIMEOUT','UNKNOWN']
+FINISHED_STATES = ['BOOT_FAIL','CANCELLED','COMPLETED','DEADLINE','FAILED','NODE_FAIL','OUT_OF_MEMORY','TIMEOUT']
+UNFINISHED_STATES = ['PENDING','RUNNING','SUSPENDED','UNKNOWN','PREEMPTED']
+
+class UnfinishedJobsService:
+    def __init__(self, config_data):
+        self.config_data = config_data
+
+    def filter_unfinished_jobs(self, logs_df: pd.DataFrame) -> pd.DataFrame:
+        '''
+        
+        Filter unfinished jobs from the logs dataframe using the 'State' column (if 'End' column is not available) or the 'End' column (if available).
+        '''
+        if 'End' in logs_df.columns:
+            mask = logs_df['End'].isna()
+        else:
+            mask = logs_df['State'].isin(UNFINISHED_STATES)
+        
+        return logs_df[mask].copy()
+    
+    def filter_finished_jobs(self, logs_df: pd.DataFrame) -> pd.DataFrame:
+        '''
+        Filter finished jobs from the logs dataframe using the 'State' column (if 'End' column is not available) or the 'End' column (if available).
+        '''
+        if 'End' in logs_df.columns:
+            mask = logs_df['End'].notna()
+        else:
+            mask = logs_df['State'].isin(FINISHED_STATES)
+        
+        return logs_df[mask].copy()

--- a/ga_dashboard/backend/services/unfinished_jobs_service.py
+++ b/ga_dashboard/backend/services/unfinished_jobs_service.py
@@ -1,5 +1,10 @@
 import pandas as pd
 
+from ga_dashboard.backend.helpers import utils
+from ga_dashboard.backend.services.database_service import DBSettings, DatabaseService
+from ga_dashboard.backend.services.sacct_service import SacctService
+from ga_dashboard.database.table_col_definitions import UNFINISHED_JOBS_COLUMNS
+
 ## States from SLURM documentation: https://slurm.schedmd.com/job_state_codes.html (as of 10 Feb 2026)
 
 SLURM_STATES = ['BOOT_FAIL','CANCELLED','COMPLETED','DEADLINE','FAILED','NODE_FAIL','OUT_OF_MEMORY','PENDING','PREEMPTED','RUNNING','SUSPENDED','TIMEOUT','UNKNOWN']
@@ -22,13 +27,69 @@ class UnfinishedJobsService:
         
         return logs_df[mask].copy()
     
+    def handle_running_jobs(self, logs_df: pd.DataFrame) -> pd.DataFrame:
+        ##Add running jobs to the database
+        return None
+
+
+    
     def filter_finished_jobs(self, logs_df: pd.DataFrame) -> pd.DataFrame:
         '''
         Filter finished jobs from the logs dataframe using the 'State' column (if 'End' column is not available) or the 'End' column (if available).
         '''
         if 'End' in logs_df.columns:
-            mask = logs_df['End'].notna()
+            mask = logs_df['End'].notna() & (logs_df['End'] != "Unknown")
         else:
             mask = logs_df['State'].isin(FINISHED_STATES)
         
         return logs_df[mask].copy()
+    
+    def sync_unfinished_jobs(self) -> pd.DataFrame:
+        '''
+        Get the list of unfinished jobs from the previous extraction (if any) to check if they are still unfinished or if they have finished in the meantime.
+        Pull the jobs using sacct command on the basis of Job IDs
+        '''
+        use_mock = True if 'use_mock' in self.config_data.keys() and self.config_data['use_mock'] else False
+        if use_mock:
+            prev_unfinished_jobs_df = pd.read_csv(self.config_data['use_mock'])
+        else:
+            db_params = DBSettings(
+                db_name=self.config_data['db_name'],
+                user=self.config_data['db_user'],
+                password=self.config_data['db_password'],
+                host=self.config_data['db_host'],
+                port=self.config_data['db_port']
+                )
+
+            with DatabaseService(db_params) as database:
+                prev_unfinished_jobs_df = database.fetch_data(
+                    table_name='unfinished_jobs',
+                    columns=UNFINISHED_JOBS_COLUMNS
+                )
+        
+        #Fetching unfinished job using sacct command
+        raw_logs = SacctService.pull_logs_by_jobid(prev_unfinished_jobs_df) 
+        raw_logs_df = utils.convert2dataframe(raw_logs, types = {'NNodes': 'int64', 'NCPUS': 'int64'})
+        finished_jobs = self.filter_finished_jobs(raw_logs_df)
+
+        return finished_jobs
+    
+    def delete_resolved_unfinished_jobs(self, finished_jobs_df: pd.DataFrame):
+        '''
+        Delete the jobs that were previously unfinished but have now finished from the 'unfinished_jobs' table in the database.
+        '''
+        db_params = DBSettings(
+            db_name=self.config_data['db_name'],
+            user=self.config_data['db_user'],
+            password=self.config_data['db_password'],
+            host=self.config_data['db_host'],
+            port=self.config_data['db_port']
+            )
+        job_ids = finished_jobs_df['JobID'].tolist()
+
+        with DatabaseService(db_params) as database:
+            database.delete_by_column_values(
+                table_name='unfinished_jobs',
+                column_name='job_id',
+                values=job_ids)
+            

--- a/ga_dashboard/backend/services/unfinished_jobs_service.py
+++ b/ga_dashboard/backend/services/unfinished_jobs_service.py
@@ -41,8 +41,8 @@ class UnfinishedJobsService:
         '''
         if 'End' in logs_df.columns:
             mask = logs_df['End'].notna() & (logs_df['End'] != "Unknown")
-        else:
-            mask = logs_df['State'].isin(FINISHED_STATES)
+        else: 
+            mask = ~logs_df['State'].isin(UNFINISHED_STATES)
         
         return logs_df[mask].copy()
     
@@ -51,24 +51,23 @@ class UnfinishedJobsService:
         Get the list of unfinished jobs from the previous extraction (if any) to check if they are still unfinished or if they have finished in the meantime.
         Pull the jobs using sacct command on the basis of Job IDs
         '''
-        use_mock = True if 'use_mock' in self.config_data.keys() and self.config_data['use_mock'] else False
-        if use_mock:
-            prev_unfinished_jobs_df = pd.read_csv(self.config_data['use_mock'])
-        else:
+        try:
             with DatabaseService(self.db_params) as database:
                 prev_unfinished_jobs_df = database.fetch_data(
                     table_name='ga_unfinished_jobs',
                     columns=UNFINISHED_JOBS_COLUMNS
                 )
-        
-        #Fetching unfinished job using sacct command
-        raw_logs = SacctService.pull_logs_by_jobid(prev_unfinished_jobs_df) 
-        if raw_logs is not None:
-            raw_logs_df = utils.convert2dataframe(raw_logs, types = {'NNodes': 'int64', 'NCPUS': 'int64'})
-            finished_jobs = self.filter_finished_jobs(raw_logs_df)
-            #creating a list to track the finished jobs ids
-            self.finished_jobids = finished_jobs['JobID'].apply(lambda x: x.split('.')[0]).unique().tolist()
-            return finished_jobs
+            
+            #Fetching unfinished job using sacct command
+            raw_logs = SacctService.pull_logs_by_jobid(prev_unfinished_jobs_df) 
+            if raw_logs is not None:
+                raw_logs_df = utils.convert2dataframe(raw_logs, types = {'NNodes': 'int64', 'NCPUS': 'int64'})
+                finished_jobs = self.filter_finished_jobs(raw_logs_df)
+                #creating a list to track the finished jobs ids
+                self.finished_jobids = finished_jobs['JobID'].apply(lambda x: x.split('.')[0]).unique().tolist()
+                return finished_jobs
+        except Exception as e:
+            print(f"Error syncing unfinished jobs {e}")
         return None
 
     def save_unfinished_jobs(self, unfinished_jobs_df: pd.DataFrame):

--- a/ga_dashboard/backend/services/unfinished_jobs_service.py
+++ b/ga_dashboard/backend/services/unfinished_jobs_service.py
@@ -63,10 +63,13 @@ class UnfinishedJobsService:
         
         #Fetching unfinished job using sacct command
         raw_logs = SacctService.pull_logs_by_jobid(prev_unfinished_jobs_df) 
-        raw_logs_df = utils.convert2dataframe(raw_logs, types = {'NNodes': 'int64', 'NCPUS': 'int64'})
-        finished_jobs = self.filter_finished_jobs(raw_logs_df)
-
-        return finished_jobs
+        if raw_logs is not None:
+            raw_logs_df = utils.convert2dataframe(raw_logs, types = {'NNodes': 'int64', 'NCPUS': 'int64'})
+            finished_jobs = self.filter_finished_jobs(raw_logs_df)
+            #creating a list to track the finished jobs ids
+            self.finished_jobids = finished_jobs['JobID'].apply(lambda x: x.split('.')[0]).unique().tolist()
+            return finished_jobs
+        return None
 
     def save_unfinished_jobs(self, unfinished_jobs_df: pd.DataFrame):
         '''
@@ -98,16 +101,17 @@ class UnfinishedJobsService:
                 rows = unfinished_jobs_df.to_dict(orient='records'),
                 columns=UNFINISHED_JOBS_COLUMNS,
             )
-    
-    def delete_resolved_unfinished_jobs(self, finished_jobs_df: pd.DataFrame):
+
+    def delete_resolved_unfinished_jobs(self):
         '''
         Delete the jobs that were previously unfinished but have now finished from the 'unfinished_jobs' table in the database.
         '''
-        job_ids = finished_jobs_df['JobID'].tolist()
-
-        with DatabaseService(self.db_params) as database:
-            database.delete_by_column_values(
-                table_name='ga_unfinished_jobs',
-                column_name='jobid',
-                values=job_ids)
+        if hasattr(self, 'finished_jobids') and self.finished_jobids:
+            with DatabaseService(self.db_params) as database:
+                database.delete_by_column_values(
+                    table_name='ga_unfinished_jobs',
+                    column_name='job_id',
+                    values=self.finished_jobids)
+        else:
+            print("No finished jobs to delete from unfinished_jobs table.")
             

--- a/ga_dashboard/backend/services/unfinished_jobs_service.py
+++ b/ga_dashboard/backend/services/unfinished_jobs_service.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import datetime
 
 from ga_dashboard.backend.helpers import utils
 from ga_dashboard.backend.services.database_service import DBSettings, DatabaseService
@@ -14,6 +15,13 @@ UNFINISHED_STATES = ['PENDING','RUNNING','SUSPENDED','UNKNOWN','PREEMPTED']
 class UnfinishedJobsService:
     def __init__(self, config_data):
         self.config_data = config_data
+        self.db_params = DBSettings(
+                db_name=self.config_data['db_name'],
+                user=self.config_data['db_user'],
+                password=self.config_data['db_password'],
+                host=self.config_data['db_host'],
+                port=self.config_data['db_port']
+                )
 
     def filter_unfinished_jobs(self, logs_df: pd.DataFrame) -> pd.DataFrame:
         '''
@@ -21,17 +29,11 @@ class UnfinishedJobsService:
         Filter unfinished jobs from the logs dataframe using the 'State' column (if 'End' column is not available) or the 'End' column (if available).
         '''
         if 'End' in logs_df.columns:
-            mask = logs_df['End'].isna()
+            mask = logs_df['End'].isna() | (logs_df['End'] == 'Unknown')
         else:
             mask = logs_df['State'].isin(UNFINISHED_STATES)
         
-        return logs_df[mask].copy()
-    
-    def handle_running_jobs(self, logs_df: pd.DataFrame) -> pd.DataFrame:
-        ##Add running jobs to the database
-        return None
-
-
+        return logs_df[mask].copy(), logs_df[~mask].copy() # Return both unfinished and finished jobs for further processing
     
     def filter_finished_jobs(self, logs_df: pd.DataFrame) -> pd.DataFrame:
         '''
@@ -53,17 +55,9 @@ class UnfinishedJobsService:
         if use_mock:
             prev_unfinished_jobs_df = pd.read_csv(self.config_data['use_mock'])
         else:
-            db_params = DBSettings(
-                db_name=self.config_data['db_name'],
-                user=self.config_data['db_user'],
-                password=self.config_data['db_password'],
-                host=self.config_data['db_host'],
-                port=self.config_data['db_port']
-                )
-
-            with DatabaseService(db_params) as database:
+            with DatabaseService(self.db_params) as database:
                 prev_unfinished_jobs_df = database.fetch_data(
-                    table_name='unfinished_jobs',
+                    table_name='ga_unfinished_jobs',
                     columns=UNFINISHED_JOBS_COLUMNS
                 )
         
@@ -73,23 +67,47 @@ class UnfinishedJobsService:
         finished_jobs = self.filter_finished_jobs(raw_logs_df)
 
         return finished_jobs
+
+    def save_unfinished_jobs(self, unfinished_jobs_df: pd.DataFrame):
+        '''
+        Save the unfinished jobs to the 'unfinished_jobs' table in the database.
+        '''
+        unfinished_jobs_df = unfinished_jobs_df.rename(columns={
+            'User':   'user_name',
+            'JobID':  'job_id',
+            'Submit': 'submitdate',
+            'Start':  'startdate',
+            'State':  'job_state',
+        })
+
+        unfinished_jobs_df['submitdate'] = pd.to_datetime(
+            unfinished_jobs_df['submitdate'],
+            format="%Y-%m-%dT%H:%M:%S",
+            errors="coerce"   # invalid parses -> NaT
+        )
+        
+        unfinished_jobs_df['startdate'] = pd.to_datetime(
+            unfinished_jobs_df['startdate'],
+            format="%Y-%m-%dT%H:%M:%S",
+            errors="coerce"   # invalid parses -> NaT
+        )
+
+        with DatabaseService(self.db_params) as database:
+            database.insert_data(
+                table_name='ga_unfinished_jobs',
+                rows = unfinished_jobs_df.to_dict(orient='records'),
+                columns=UNFINISHED_JOBS_COLUMNS,
+            )
     
     def delete_resolved_unfinished_jobs(self, finished_jobs_df: pd.DataFrame):
         '''
         Delete the jobs that were previously unfinished but have now finished from the 'unfinished_jobs' table in the database.
         '''
-        db_params = DBSettings(
-            db_name=self.config_data['db_name'],
-            user=self.config_data['db_user'],
-            password=self.config_data['db_password'],
-            host=self.config_data['db_host'],
-            port=self.config_data['db_port']
-            )
         job_ids = finished_jobs_df['JobID'].tolist()
 
-        with DatabaseService(db_params) as database:
+        with DatabaseService(self.db_params) as database:
             database.delete_by_column_values(
-                table_name='unfinished_jobs',
-                column_name='job_id',
+                table_name='ga_unfinished_jobs',
+                column_name='jobid',
                 values=job_ids)
             

--- a/ga_dashboard/backend/services/unfinished_jobs_service.py
+++ b/ga_dashboard/backend/services/unfinished_jobs_service.py
@@ -31,7 +31,8 @@ class UnfinishedJobsService:
         if 'End' in logs_df.columns:
             mask = logs_df['End'].isna() | (logs_df['End'] == 'Unknown')
         else:
-            mask = logs_df['State'].isin(UNFINISHED_STATES)
+            ## NOTE: This is a temporary workaround for retrocompatibility since in earlier versions 'End' field was not fetched. Must be removed eventually.
+            mask = logs_df['State'].isin(UNFINISHED_STATES) 
         
         return logs_df[mask].copy(), logs_df[~mask].copy() # Return both unfinished and finished jobs for further processing
     
@@ -42,7 +43,8 @@ class UnfinishedJobsService:
         if 'End' in logs_df.columns:
             mask = logs_df['End'].notna() & (logs_df['End'] != "Unknown")
         else: 
-            mask = ~logs_df['State'].isin(UNFINISHED_STATES)
+            ## NOTE: This is a temporary workaround for retrocompatibility since in earlier versions 'End' field was not fetched. Must be removed eventually.
+            mask = ~logs_df['State'].isin(UNFINISHED_STATES) 
         
         return logs_df[mask].copy()
     

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -365,7 +365,7 @@ class SlurmManager(SlurmBase):
             self.logs_df['Account_'] = ''
 
         ### Aggregate per jobID
-        self.df_agg = self.logs_df.groupby('single_jobID').agg({
+        self.df_agg_0 = self.logs_df.groupby('single_jobID').agg({
             'TotalCPUtime_': 'max',
             'CPUwallclocktime_': 'max',
             'WallclockTimeX': 'max',
@@ -489,10 +489,10 @@ class SlurmManager(SlurmBase):
 
         self.unfinished_jobs = grouped_by_job
 
-    def filter_and_store_unfinished_jobs(self, unfin_jobs_service: UnfinishedJobsService):
+    def filter_and_store_unfinished_jobs(self, unfinished_jobs_service: UnfinishedJobsService):
         '''
             Use the UnfinishedJobsService to filter out unfinished jobs from the logs dataframe, and store them in the database.
         '''
-        self.unfinished_jobs, self.logs_df = unfin_jobs_service.filter_unfinished_jobs(self.logs_df)
+        self.unfinished_jobs, self.logs_df = unfinished_jobs_service.filter_unfinished_jobs(self.logs_df)
         self.select_distinct_unfinished_jobs()
-        unfin_jobs_service.save_unfinished_jobs(self.unfinished_jobs)
+        unfinished_jobs_service.save_unfinished_jobs(self.unfinished_jobs)

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -338,17 +338,6 @@ class SlurmManager(SlurmBase):
         self.logs_df['SubmitDatetimeX'] = self.logs_df.Submit.apply(
             lambda x: datetime.datetime.strptime(x, "%Y-%m-%dT%H:%M:%S"))
         
-        self.logs_df['StartDatetimeX'] = pd.to_datetime(
-            self.logs_df['Start'],
-            format="%Y-%m-%dT%H:%M:%S",
-            errors="coerce"   # invalid parses -> NaT
-        )
-
-        self.logs_df['EndDatetimeX'] = pd.to_datetime(
-            self.logs_df['End'],
-            format="%Y-%m-%dT%H:%M:%S",
-            errors="coerce"   # invalid parses -> NaT
-        )
         ### Number of CPUs
         # e.g. here there is no cleaning necessary, so I just standardise the column name
         self.logs_df['NCPUS_'] = self.logs_df.NCPUS
@@ -398,8 +387,7 @@ class SlurmManager(SlurmBase):
             'StateX': 'min',
             'Account_': 'first',
             'UIDX': 'first',
-            'UserX': 'first',
-            'EndDatetimeX': lambda x: x.max() if x.notnull().all() else pd.NaT
+            'UserX': 'first'
         })
 
         ### Remove jobs that are still running or currently queued

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -449,7 +449,7 @@ class SlurmManager(SlurmBase):
 
         self.df_agg_X = self.df_agg[[x for x in self.df_agg.columns if x[-1] == 'X']]
 
-    def concat_logs_df(self, new_logs_df):
+    def concat_logs_df(self, new_logs_df: pd.DataFrame):
         """
         Concatenate the existing logs dataframe with a new one, for example when we want to add finished jobs to previously-fetched logs.
         :param new_logs_df: [pd.DataFrame] new logs dataframe to concatenate with the existing one.
@@ -472,7 +472,7 @@ class SlurmManager(SlurmBase):
 
         df = self.unfinished_jobs.copy()
 
-        def pick_unfinished_state(states):
+        def pick_unfinished_state(states: list):
             for state in states:
                 if state in UNFINISHED_STATES:
                     return state

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ga_dashboard.backend.helpers import utils
 from ga_dashboard.backend.services.sacct_service import SacctService
-from ga_dashboard.backend.services.unfinished_jobs_service import UnfinishedJobsService
+from ga_dashboard.backend.services.unfinished_jobs_service import UNFINISHED_STATES, UnfinishedJobsService
 
 class SlurmBase:
     """
@@ -482,3 +482,41 @@ class SlurmManager(SlurmBase):
             raise ValueError("logs_df is not initialised. Run pull_logs() and raw_logs_to_df() first.")
         
         self.logs_df = pd.concat([self.logs_df, new_logs_df], ignore_index=True)
+
+    def select_distinct_unfinished_jobs(self):
+        '''
+        Select distinct unfinished jobs, to avoid duplicates in the database.
+        For jobs with multiple rows (subprocesses), picks:
+        - oldest Start date
+        - Submit date (should be the same across rows)
+        - State that is unfinished (if any subprocess is unfinished, the job is unfinished)
+        '''
+        if self.unfinished_jobs is None:
+            raise ValueError("unfinished_jobs is not initialised. Run filter_and_store_unfinished_jobs() first.")
+
+        df = self.unfinished_jobs.copy()
+
+        def pick_unfinished_state(states):
+            for state in states:
+                if state in UNFINISHED_STATES:
+                    return state
+            return states.iloc[0]
+
+        df['JobID_base'] = df['JobID'].astype(str).str.split('.').str[0]
+
+        grouped_by_job = df.groupby('JobID_base').agg(
+            User=('User', 'first'),
+            Start=('Start', 'min'),
+            Submit=('Submit', 'first'),
+            State=('State', pick_unfinished_state), # picking the unfinished state if there are multiple rows for the same job.
+        ).reset_index().rename(columns={'JobID_base': 'JobID'})
+
+        self.unfinished_jobs = grouped_by_job
+
+    def filter_and_store_unfinished_jobs(self, unfin_jobs_service: UnfinishedJobsService):
+        '''
+            Use the UnfinishedJobsService to filter out unfinished jobs from the logs dataframe, and store them in the database.
+        '''
+        self.unfinished_jobs, self.logs_df = unfin_jobs_service.filter_unfinished_jobs(self.logs_df)
+        self.select_distinct_unfinished_jobs()
+        unfin_jobs_service.save_unfinished_jobs(self.unfinished_jobs)

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -365,7 +365,7 @@ class SlurmManager(SlurmBase):
             self.logs_df['Account_'] = ''
 
         ### Aggregate per jobID
-        self.df_agg_0 = self.logs_df.groupby('single_jobID').agg({
+        self.df_agg = self.logs_df.groupby('single_jobID').agg({
             'TotalCPUtime_': 'max',
             'CPUwallclocktime_': 'max',
             'WallclockTimeX': 'max',

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -212,7 +212,6 @@ class SlurmBase:
         # Codes are found here: https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
         # self.args.customSuccessStates = 'TO,TIMEOUT'
         success_codes = ['CD', 'COMPLETED']
-        running_codes = ['PD', 'PENDING', 'R', 'RUNNING', 'RQ', 'REQUEUED']
         if x in success_codes:
             codeState = 1
         elif x in customSuccessStates_list:
@@ -221,11 +220,6 @@ class SlurmBase:
             codeState = -1
         else:
             codeState = 0
-
-        if x in running_codes:
-            # running jobs are the lowest to be removed all the time
-            # (if one of the subprocess is still running, the job gets ignored regardless of --customSuccessStates
-            codeState = -2
 
         return codeState
 
@@ -334,7 +328,7 @@ class SlurmManager(SlurmBase):
         # Make sure it's either a partition name, or a comma-separated list of partitions
         self.logs_df['PartitionX'] = self.logs_df.apply(self.clean_partition, axis=1)
 
-        ### Parse datetimes - Submit, Start, End
+        ### Parse datetimes - Submit
         self.logs_df['SubmitDatetimeX'] = self.logs_df.Submit.apply(
             lambda x: datetime.datetime.strptime(x, "%Y-%m-%dT%H:%M:%S"))
         
@@ -390,8 +384,6 @@ class SlurmManager(SlurmBase):
             'UserX': 'first'
         })
 
-        ### Remove jobs that are still running or currently queued
-        self.df_agg = self.df_agg_0.loc[self.df_agg_0.StateX != -2]
         self.df_agg.loc[self.df_agg.StateX == -1, 'StateX'] = 1 # Turn StateX==-1 into 1 (customSuccessStates are considered successful i.e. 1)
 
         ### Replace UsedMem_=-1 with memory requested (for when MaxRSS=NaN)

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -402,10 +402,6 @@ class SlurmManager(SlurmBase):
             'EndDatetimeX': lambda x: x.max() if x.notnull().all() else pd.NaT
         })
 
-        ## Handle running jobs; they get added to the database by UnfinishedJobsService
-        df_agg_running = self.df_agg_0.loc[self.df_agg_0.StateX == -2] # State is in running_codes
-        UnfinishedJobsService(config_data=self.config_data).handle_running_jobs(df_agg_running) #TODO
-
         ### Remove jobs that are still running or currently queued
         self.df_agg = self.df_agg_0.loc[self.df_agg_0.StateX != -2]
         self.df_agg.loc[self.df_agg.StateX == -1, 'StateX'] = 1 # Turn StateX==-1 into 1 (customSuccessStates are considered successful i.e. 1)

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -1,9 +1,11 @@
 import datetime
 import os
 import pandas as pd
-from io import BytesIO
+import numpy as np
 
+from ga_dashboard.backend.helpers import utils
 from ga_dashboard.backend.services.sacct_service import SacctService
+from ga_dashboard.backend.services.unfinished_jobs_service import UnfinishedJobsService
 
 class SlurmBase:
     """
@@ -259,17 +261,6 @@ class SlurmManager(SlurmBase):
         self.df_agg = None
         self.df_agg_X = None
 
-    @staticmethod
-    def convert2dataframe(logs_raw):
-        """
-        Convert raw logs output into a pandas DataFrame.
-        Can be called independently with any raw logs.
-        """
-        logs_df = pd.read_csv(BytesIO(logs_raw), sep="|", dtype='str')
-        for x in ['NNodes', 'NCPUS']:
-            logs_df[x] = logs_df[x].astype('int64')
-        return logs_df
-
     def pull_logs(self):
         """
         Run the command line to pull usage from the workload manager.
@@ -301,7 +292,8 @@ class SlurmManager(SlurmBase):
         """
         Convert raw logs output into a pandas dataframe - calling the static method convert2dataframe
         """
-        self.logs_df = SlurmManager.convert2dataframe(self.logs_raw)
+        delimiter = "," if 'useCustomLogs' in self.config_data.keys() and self.config_data['useCustomLogs'] != '' else "|"
+        self.logs_df = utils.convert2dataframe(self.logs_raw, types = {'NNodes': 'int64', 'NCPUS': 'int64'}, delimiter=delimiter)
 
 
     def clean_logs_df(self):
@@ -407,13 +399,16 @@ class SlurmManager(SlurmBase):
             'Account_': 'first',
             'UIDX': 'first',
             'UserX': 'first',
+            'EndDatetimeX': lambda x: x.max() if x.notnull().all() else pd.NaT
         })
+
+        ## Handle running jobs; they get added to the database by UnfinishedJobsService
+        df_agg_running = self.df_agg_0.loc[self.df_agg_0.StateX == -2] # State is in running_codes
+        UnfinishedJobsService(config_data=self.config_data).handle_running_jobs(df_agg_running) #TODO
 
         ### Remove jobs that are still running or currently queued
         self.df_agg = self.df_agg_0.loc[self.df_agg_0.StateX != -2]
-
-        ### Turn StateX==-2 into 1
-        self.df_agg.loc[self.df_agg.StateX == -1, 'StateX'] = 1
+        self.df_agg.loc[self.df_agg.StateX == -1, 'StateX'] = 1 # Turn StateX==-1 into 1 (customSuccessStates are considered successful i.e. 1)
 
         ### Replace UsedMem_=-1 with memory requested (for when MaxRSS=NaN)
         self.df_agg['UsedMem2_'] = self.df_agg.apply(self.clean_UsedMem, axis=1)
@@ -477,3 +472,13 @@ class SlurmManager(SlurmBase):
                 self.df_agg = self.df_agg.loc[self.df_agg.Account_ == self.config_data['filterAccount']]
 
         self.df_agg_X = self.df_agg[[x for x in self.df_agg.columns if x[-1] == 'X']]
+
+    def concat_logs_df(self, new_logs_df):
+        """
+        Concatenate the existing logs dataframe with a new one, for example when we want to add finished jobs to previously-fetched logs.
+        :param new_logs_df: [pd.DataFrame] new logs dataframe to concatenate with the existing one.
+        """
+        if self.logs_df is None:
+            raise ValueError("logs_df is not initialised. Run pull_logs() and raw_logs_to_df() first.")
+        
+        self.logs_df = pd.concat([self.logs_df, new_logs_df], ignore_index=True)

--- a/ga_dashboard/backend/workload_manager/slurm.py
+++ b/ga_dashboard/backend/workload_manager/slurm.py
@@ -342,10 +342,21 @@ class SlurmManager(SlurmBase):
         # Make sure it's either a partition name, or a comma-separated list of partitions
         self.logs_df['PartitionX'] = self.logs_df.apply(self.clean_partition, axis=1)
 
-        ### Parse submit datetime
+        ### Parse datetimes - Submit, Start, End
         self.logs_df['SubmitDatetimeX'] = self.logs_df.Submit.apply(
             lambda x: datetime.datetime.strptime(x, "%Y-%m-%dT%H:%M:%S"))
+        
+        self.logs_df['StartDatetimeX'] = pd.to_datetime(
+            self.logs_df['Start'],
+            format="%Y-%m-%dT%H:%M:%S",
+            errors="coerce"   # invalid parses -> NaT
+        )
 
+        self.logs_df['EndDatetimeX'] = pd.to_datetime(
+            self.logs_df['End'],
+            format="%Y-%m-%dT%H:%M:%S",
+            errors="coerce"   # invalid parses -> NaT
+        )
         ### Number of CPUs
         # e.g. here there is no cleaning necessary, so I just standardise the column name
         self.logs_df['NCPUS_'] = self.logs_df.NCPUS

--- a/ga_dashboard/database/ga_db.sql
+++ b/ga_dashboard/database/ga_db.sql
@@ -40,8 +40,6 @@ DROP TABLE IF EXISTS public.ga_data_aggregate; -- Needed due to postgres caching
 CREATE TABLE public.ga_data_aggregate (
     user_name character varying(255),
     submitdate date,
-    startdate date,
-    enddate date,
     n_jobs integer,
     first_job_period date,
     last_job_period date,
@@ -106,6 +104,28 @@ CREATE TABLE public.ga_user (
 
 ALTER TABLE ONLY public.ga_user
     ADD CONSTRAINT ga_user_pkey PRIMARY KEY (user_name);
+
+--
+-- Name: ga_unfinished_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
+DROP TABLE IF EXISTS public.ga_unfinished_jobs; -- Needed due to postgres caching
+
+CREATE TABLE public.ga_unfinished_jobs (
+    job_id character varying(255),
+    user_name character varying(255),
+    submitdate date,
+    startdate date,
+    job_state character varying(255)
+);
+
+
+--
+-- Name: ga_data_aggregate ga_data_aggregate_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ga_unfinished_jobs
+    ADD CONSTRAINT ga_unfinished_jobs_pkey PRIMARY KEY (job_id);
 
 
 --

--- a/ga_dashboard/database/ga_db.sql
+++ b/ga_dashboard/database/ga_db.sql
@@ -40,6 +40,8 @@ DROP TABLE IF EXISTS public.ga_data_aggregate; -- Needed due to postgres caching
 CREATE TABLE public.ga_data_aggregate (
     user_name character varying(255),
     submitdate date,
+    startdate date,
+    enddate date,
     n_jobs integer,
     first_job_period date,
     last_job_period date,

--- a/ga_dashboard/database/table_col_definitions.py
+++ b/ga_dashboard/database/table_col_definitions.py
@@ -16,4 +16,4 @@ GA_DATA_AGGREGATE_COLUMNS = [
 
 GA_USER_COLUMNS = ['user_name', 'uid', 'name', 'group_name', 'department', 'updated']
 
-UNFINISHED_JOBS_COLUMNS = ['job_id', "user_name",'submitdate', 'startdate','job_state']
+UNFINISHED_JOBS_COLUMNS = ['job_id', 'user_name', 'submitdate', 'startdate', 'job_state']

--- a/ga_dashboard/database/table_col_definitions.py
+++ b/ga_dashboard/database/table_col_definitions.py
@@ -16,4 +16,4 @@ GA_DATA_AGGREGATE_COLUMNS = [
 
 GA_USER_COLUMNS = ['user_name', 'uid', 'name', 'group_name', 'department', 'updated']
 
-RUNNING_JOBS_COLUMNS = ['job_id', 'submite_date']
+UNFINISHED_JOBS_COLUMNS = ['job_id', 'submit_date','state']

--- a/ga_dashboard/database/table_col_definitions.py
+++ b/ga_dashboard/database/table_col_definitions.py
@@ -16,4 +16,4 @@ GA_DATA_AGGREGATE_COLUMNS = [
 
 GA_USER_COLUMNS = ['user_name', 'uid', 'name', 'group_name', 'department', 'updated']
 
-UNFINISHED_JOBS_COLUMNS = ['job_id', 'submit_date','state']
+UNFINISHED_JOBS_COLUMNS = ['job_id', "user_name",'submitdate', 'startdate','job_state']


### PR DESCRIPTION
Issue #133 
(process notes with help from ClaudeAI)

## Unfinished Jobs Handling

Jobs still in `PENDING`, `RUNNING`, `SUSPENDED`, `PREEMPTED`, or `UNKNOWN` state at pipeline runtime can't be fully accounted for. Following steps capture them and re-processes them once they finish.

### Lifecycle across two runs

**Run N**
1. Pull Slurm logs
2. Detect unfinished jobs — checks `End` date first (missing or `"Unknown"`); falls back to `State` only if `End` column is absent
3. Save them to the `ga_unfinished_jobs` DB table

**Run N+1**
1. Fetch previously stored job IDs from `ga_unfinished_jobs`
2. Re-query `sacct` by Job ID to check for completion
3. Re-inject any now-finished jobs into the main dataframe
4. Enrich → Summarise → Insert to DB
5. **Only then** delete resolved jobs from `ga_unfinished_jobs` (prevents data loss if insert fails)

### Relevant files
- `unfinished_jobs_service.py` — DB interactions and `sacct` re-querying
- `ga_tools.py` → `extract_data()` — orchestrates detection, recovery, re-injection
- `ga_tools.py` → `process_and_store()` — triggers safe deletion post-insert

### State reference

| | States |
|---|---|
| **Finished** | `BOOT_FAIL`, `CANCELLED`, `COMPLETED`, `DEADLINE`, `FAILED`, `NODE_FAIL`, `OUT_OF_MEMORY`, `TIMEOUT` |
| **Unfinished** | `PENDING`, `RUNNING`, `SUSPENDED`, `UNKNOWN`, `PREEMPTED` |