### PR TITLE
Attribute error 130 navirah

### DIFF
--- a/scripts/add_users.py
+++ b/scripts/add_users.py
@@ -17,14 +17,19 @@ class GADashboardAddUsers (GADashboardInstall):
 
     """
 
-    def __init__(self, config_file: str) -> None:
+    def __init__(self, config_file: str, db_pass: str = None, grafana_pass: str = None) -> None:
         """
         Initialise GADashboardInstall object.
         
         Parameters
         ----------
         config_file : str. Name of the config file to use.
+        db_pass: Database password
+        grafana_pass: Grafana admin password
         """
+
+        # Calling parent to set up self.config_file, self.db_pass, self.grafana_pass, self.got_db_password, self.got_grafana_admin_password
+        super().init(config_file, db_pass, grafana_pass)
 
         # Scripts variables/config
         self.scripts = OrderedDict({
@@ -40,14 +45,6 @@ class GADashboardAddUsers (GADashboardInstall):
                              "dashboard_folder_name", "dashboard_users_file", "debug"]
             }
         })
-
-        # We will only need to get these once at most per program operation.
-        self.got_db_password = False
-        self.got_grafana_admin_password = False
-
-        # Fetch config file data
-        self.config_file = config_file
-        self.ingest_config_file()
   
 
 # e.g. python scripts/add_users.py --config my_config.yaml
@@ -57,9 +54,15 @@ if __name__ == "__main__":
     
     argparser.add_argument("--config", help='Name of config file for your parameter values.', required=True, \
                             metavar='CONFIG_FILE', dest='config')
+    argparser.add_argument("--db_pass", help='Database password (optional, to avoid entering it in the prompt).', \
+                            metavar='DB_PASS', dest='db_pass')
+    argparser.add_argument("--grafana_pass", help='Grafana admin password (optional, to avoid entering it in the prompt).', \
+                            metavar='GRAFANA_PASS', dest='grafana_pass')
 
     args = argparser.parse_args()
     config_file = args.config
+    db_pass = args.db_pass
+    grafana_pass = args.grafana_pass
 
-    runner = GADashboardAddUsers(config_file)
+    runner = GADashboardAddUsers(config_file, db_pass, grafana_pass)
     runner.run_pipeline()

--- a/scripts/add_users.py
+++ b/scripts/add_users.py
@@ -1,4 +1,5 @@
 # Python script to add Dashboard users to the Postgres database and Grafana instance.
+# NOTE: Grafana must be running for this script to successfully run.
 
 # Note: we assume that the scripts (including this one) are invoked from the top-level directory
 # in the repository (i.e. the parent directory of scripts/).
@@ -29,7 +30,7 @@ class GADashboardAddUsers (GADashboardInstall):
         """
 
         # Calling parent to set up self.config_file, self.db_pass, self.grafana_pass, self.got_db_password, self.got_grafana_admin_password
-        super().init(config_file, db_pass, grafana_pass)
+        super().__init__(config_file, db_pass, grafana_pass)
 
         # Scripts variables/config
         self.scripts = OrderedDict({


### PR DESCRIPTION
Issue/Bug: #130 

- Changes in the `add_users.py` script
- Now accepts `db_pass` and `grafana_pass` as command line args
- Resolved the Attribute Not Found error by calling `super().__init__(config_file, db_pass, grafana_pass)` and removing redundant code from `GADashboardAddUsers`