### PR TITLE
UnfinishedJobsService obj initialisation fixed 

### DIFF
--- a/ga_dashboard/backend/ga_tools.py
+++ b/ga_dashboard/backend/ga_tools.py
@@ -154,7 +154,7 @@ def extract_data(config_data: dict, has_slurmAdmin: bool, cluster_info, db_param
     ### Log the output for debugging
     utils.save_slurm_logs(config_data, WM)
 
-    unfinished_jobs_service = UnfinishedJobsService(config_data)
+    unfinished_jobs_service = UnfinishedJobsService(config_data, db_params)
 
     ### Turn usage logs into DataFrame
     WM.raw_logs_to_df()


### PR DESCRIPTION
class UnfinishedJobsService requires two parameters to be initialized. db_params was missing from this initialization throwing an error. 

Why this bug?
Commit 9007057 has correct object initialization, but later in the commit c7f28c5 db_params is removed causing the issue - potentially due to incorrect conflict resolution or other merge issues.