### PR TITLE
Fix date handling in GA_tools to advance to next day's midnight

### DIFF
--- a/ga_dashboard/backend/ga_tools.py
+++ b/ga_dashboard/backend/ga_tools.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pandas as pd
 import yaml
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 from ga_dashboard.backend.services.carbon_intensity_service import CarbonIntensityService, JobEmissionRecord
 import ga_dashboard.backend.helpers.utils as utils
@@ -122,7 +122,9 @@ class GA_tools:
             day_avg_CI = daily_avg_CI.get(current_day.strftime('%d-%m-%Y'), None)
 
             day_job_emissions.append(JobEmissionRecord(current_day, energy_per_hr, hours, day_avg_CI))
-            current_day += pd.Timedelta(days=1)
+            
+            # Advance to midnight of next day
+            current_day = datetime.combine(current_day.date() + timedelta(days=1), time.min)
 
         return JobEmissionRecord.calc_carbon_emission(day_job_emissions, energy_per_hr)
 


### PR DESCRIPTION
### Bug: 
The day-iteration loop advanced `current_day` by adding 24 hours `(+= pd.Timedelta(days=1))`, which preserves the time-of-day component from the job's start. So on the second iteration, instead of beginning at `00:00:00`, current_day would be e.g. `day2 19:40:00`. This made `day_start = 19:40:00`, while `day_end` was correctly capped at the job's end time of e.g. `00:21:00`,  producing a negative duration and therefore a negative carbon footprint for any job crossing midnight.
### Fix: 
Replace the increment with `datetime.combine(current_day.date() + timedelta(days=1), time.min)`, which explicitly resets the time component to `00:00:00` at the start of each new day, regardless of when the job started.

### Testing the fix:
Tested this fix by comparing the carbon emissions calculated in the following cases to be exactly the same:

1. When `postcode` NOT in `cluster_info.yaml` - i.e. using the default CI value and older simpler Carbon emissions calculation.
2. When `postcode` is in  `cluster_info.yaml` but `JobEmissionRecord.carbon_intensity` is hard coded to default CI value.

Confirmed that in both cases the calculated carbon emissions for each jobs is the same - hence confirming the issue is fixed.