### PR TITLE
Added carbon footprint of failed jobs plots for user and institution

### DIFF
--- a/ga_dashboard/dashboards/ga_user.json
+++ b/ga_dashboard/dashboards/ga_user.json
@@ -2190,7 +2190,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "% of failed jobs",
+            "axisLabel": "Carbon footprint of failed jobs (in red)",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "barWidthFactor": 0.6,
@@ -2247,7 +2247,7 @@
               },
               {
                 "id": "unit",
-                "value": "percent"
+                "value": "massg"
               }
             ]
           },
@@ -2259,7 +2259,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "percent"
+                "value": "massg"
               }
             ]
           }
@@ -2274,7 +2274,9 @@
       "id": 66,
       "options": {
         "legend": {
-          "calcs": [],
+          "calcs": [
+            "mean"
+          ],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -2295,7 +2297,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT submitdate, (SUM(n_jobs-n_success)::float/SUM(n_jobs))*100 AS \"Failed jobs\",  (SUM(n_success)::float/SUM(n_jobs))*100 AS \"Successful jobs\" FROM ga_data_aggregate WHERE user_name = '${__user.login}' GROUP BY submitdate ORDER BY submitdate ASC;",
+          "rawSql": "SELECT\n  submitdate,\n  SUM(carbonfootprint_failedjobs) AS \"Failed jobs\",\n  SUM(carbonfootprint-carbonfootprint_failedjobs) AS \"Successful jobs\"\nFROM\n  ga_data_aggregate\nWHERE\n  user_name = '${__user.login}'\nGROUP BY\n  submitdate\nORDER BY\n  submitdate ASC;\n",
           "refId": "A",
           "sql": {
             "columns": [
@@ -2316,7 +2318,7 @@
           }
         }
       ],
-      "title": "User's distribution of failed jobs",
+      "title": "User's carbon footprint of Failed vs Successful jobs",
       "type": "timeseries"
     },
     {
@@ -5878,7 +5880,7 @@
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "% of failed jobs (in red)",
+                "axisLabel": "Carbon footprint of failed jobs (in red)",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
@@ -5921,7 +5923,8 @@
                     "value": 80
                   }
                 ]
-              }
+              },
+              "unit": "massg"
             },
             "overrides": [
               {
@@ -5939,7 +5942,7 @@
                   },
                   {
                     "id": "unit",
-                    "value": "percent"
+                    "value": "massg"
                   }
                 ]
               },
@@ -5951,7 +5954,7 @@
                 "properties": [
                   {
                     "id": "unit",
-                    "value": "percent"
+                    "value": "massg"
                   }
                 ]
               }
@@ -5966,7 +5969,9 @@
           "id": 53,
           "options": {
             "legend": {
-              "calcs": [],
+              "calcs": [
+                "mean"
+              ],
               "displayMode": "list",
               "placement": "bottom",
               "showLegend": true
@@ -5987,7 +5992,7 @@
               "editorMode": "code",
               "format": "table",
               "rawQuery": true,
-              "rawSql": "SELECT submitdate, (SUM(n_jobs-n_success)::float/SUM(n_jobs))*100 AS \"Failed jobs\",  (SUM(n_success)::float/SUM(n_jobs))*100 AS \"Successful jobs\" FROM ga_data_aggregate GROUP BY submitdate ORDER BY submitdate ASC; \n",
+              "rawSql": "SELECT submitdate, SUM(carbonfootprint_failedjobs) AS \"Failed jobs\",  SUM(carbonfootprint-carbonfootprint_failedjobs) AS \"Successful jobs\" FROM ga_data_aggregate GROUP BY submitdate ORDER BY submitdate ASC; \n",
               "refId": "A",
               "sql": {
                 "columns": [
@@ -6045,7 +6050,7 @@
               "table": "ga_data"
             }
           ],
-          "title": "Distribution Failed vs Successful jobs",
+          "title": "Carbon footprint of Failed vs Successful jobs",
           "type": "timeseries"
         },
         {


### PR DESCRIPTION
Issue #101 

Added **carbon footprint of failed jobs plot** to the 'Failed jobs vs Successful jobs' section for User and Institution.
Removed the percent failed jobs plot for both.

Previous query (User):
```
SELECT
  submitdate,
  (SUM(n_jobs - n_success)::float / SUM(n_jobs)) * 100 AS "Failed jobs",
  (SUM(n_success)::float / SUM(n_jobs)) * 100 AS "Successful jobs"
FROM ga_data_aggregate
WHERE user_name = '${__user.login}'
GROUP BY submitdate
ORDER BY submitdate ASC;
```

New query (User):
```
SELECT
  submitdate,
  SUM(carbonfootprint_failedjobs) AS "Failed jobs",
  SUM(carbonfootprint - carbonfootprint_failedjobs) AS "Successful jobs"
FROM ga_data_aggregate
WHERE user_name = '${__user.login}'
GROUP BY submitdate
ORDER BY submitdate ASC;
```
<img width="774" height="380" alt="Screenshot 2026-03-30 at 16 29 57" src="https://github.com/user-attachments/assets/a607293d-863e-4e86-91ad-c3d64edb3608" />

Previous query (Institution):
```
SELECT
  submitdate,
  (SUM(n_jobs - n_success)::float / SUM(n_jobs)) * 100 AS "Failed jobs",
  (SUM(n_success)::float / SUM(n_jobs)) * 100 AS "Successful jobs"
FROM ga_data_aggregate
GROUP BY submitdate
ORDER BY submitdate ASC;
```

New query (Institution):
```
SELECT
  submitdate,
  SUM(carbonfootprint_failedjobs) AS "Failed jobs",
  SUM(carbonfootprint - carbonfootprint_failedjobs) AS "Successful jobs"
FROM ga_data_aggregate
GROUP BY submitdate
ORDER BY submitdate ASC;
```

<img width="1092" height="377" alt="Screenshot 2026-03-30 at 16 25 25" src="https://github.com/user-attachments/assets/638e73f2-3aaf-4e64-bcfe-73763ba06aee" />


Note: created new Issue #155 and sub issue #156 to add energy usage of failed jobs field and plot on dashboard.